### PR TITLE
Feat/modal improvements

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -16,8 +16,8 @@ export const Provider: GlobalProvider = ({ children }) => (
         <GitHub className="w-6 h-6" />
       </a>
     </header>
-    <main>
+    <section>
       {children}
-    </main>
+    </section>
   </>
 );

--- a/.ladle/config.mjs
+++ b/.ladle/config.mjs
@@ -2,6 +2,7 @@ export default {
   addons: {
     theme: { enabled: false },
     mode: { enabled: false },
+    width: { enabled: false },
     ladle: { enabled: false }
   }
 }

--- a/.ladle/stories.css
+++ b/.ladle/stories.css
@@ -27,6 +27,10 @@
     @apply capitalize;
   }
 
+  .ladle-aside, .ladle-aside input {
+    @apply bg-[color:var(--ladle-bg-color-secondary)];
+  }
+
   .ladle-addons {
     @apply mt-8;
   }
@@ -43,6 +47,10 @@
     div[data-reach-dialog-content] {
       @apply bottom-16 w-[auto];
     }
+  }
+
+  body {
+    --ladle-main-padding-mobile: 2rem;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/src/Modal/ModalComponent.tsx
+++ b/src/Modal/ModalComponent.tsx
@@ -9,12 +9,15 @@ import {
   useState,
   useImperativeHandle,
   useEffect,
+  FC,
+  RefAttributes,
 } from 'react';
 import { X } from 'react-feather';
 
-interface ModalProps {
+interface ModalFCProps {
   title: string;
   titleProps?: HTMLAttributes<HTMLHeadingElement>;
+  headerProps?: HTMLAttributes<HTMLHeadElement>;
   contentProps?: Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'aria-labelledby'>;
   onClosed?: () => void;
 }
@@ -24,7 +27,9 @@ export interface ModalRef {
   closeModal: () => void;
 }
 
-export const Modal = forwardRef<ModalRef, PropsWithChildren<ModalProps>>(
+export type ModalComponentProps = FC<PropsWithChildren<ModalFCProps> & RefAttributes<ModalRef>>;
+
+export const ModalComponent: ModalComponentProps = forwardRef<ModalRef, PropsWithChildren<ModalFCProps>>(
   (
     {
       title,
@@ -32,6 +37,7 @@ export const Modal = forwardRef<ModalRef, PropsWithChildren<ModalProps>>(
       onClosed,
       contentProps: { className: contentClassName, ...contentProps } = {},
       titleProps: { id, className: titleClassName, ...titleProps } = {},
+      headerProps: { className: headerClassName, ...headerProps } = {},
     },
     ref
   ) => {
@@ -100,29 +106,30 @@ export const Modal = forwardRef<ModalRef, PropsWithChildren<ModalProps>>(
           role="dialog"
           aria-labelledby={titleId}
           className={cx(
-            'relative flex flex-col rounded-2xl p-8',
+            'relative flex flex-col rounded-xl p-6',
             'bg-white text-base text-gray-500',
             'dark:bg-gray-900 dark:fill-gray-400 dark:text-gray-400',
             closing ? 'animate-modal-shrink opacity-0' : 'animate-modal-grow',
             contentClassName
           )}
         >
-          <X
-            className="absolute top-0 right-0 h-8 w-8 cursor-pointer rounded-full p-1 hover:bg-gray-200 dark:hover:bg-gray-700"
-            onClick={closeModal}
-          />
-          <h3
-            {...titleProps}
-            id={titleId}
-            className={cx('m-0 mb-6 text-xl font-bold capitalize', titleClassName)}
-          >
-            {title}
-          </h3>
+          <header {...headerProps} className={cx('flex items-center space-x-1', headerClassName)}>
+            <h1
+              {...titleProps}
+              id={titleId}
+              className={cx('m-0 grow truncate text-xl font-bold capitalize', titleClassName)}
+            >
+              {title}
+            </h1>
+            <X
+              className="h-8 w-8 shrink-0 cursor-pointer rounded-full p-1 hover:bg-gray-200 dark:hover:bg-gray-700"
+              onClick={closeModal}
+            />
+          </header>
           {children}
         </div>
       </dialog>
     );
   }
 );
-
-Modal.displayName = 'Modal';
+ModalComponent.displayName = 'Modal';

--- a/src/Modal/ModalContent.tsx
+++ b/src/Modal/ModalContent.tsx
@@ -1,0 +1,6 @@
+import { FC, HTMLAttributes, PropsWithChildren } from 'react';
+
+export const ModalContent: FC<PropsWithChildren<HTMLAttributes<HTMLElement>>> = ({
+  children,
+  ...props
+}) => <section {...props}>{children}</section>;

--- a/src/Modal/ModalFooter.tsx
+++ b/src/Modal/ModalFooter.tsx
@@ -1,0 +1,12 @@
+import cx from 'classnames';
+import { FC, HTMLAttributes, PropsWithChildren } from 'react';
+
+export const ModalFooter: FC<PropsWithChildren<HTMLAttributes<HTMLElement>>> = ({
+  children,
+  className,
+  ...props
+}) => (
+  <footer {...props} className={cx('flex justify-end px-1', className)}>
+    {children}
+  </footer>
+);

--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -1,0 +1,12 @@
+import { ModalComponent, ModalComponentProps } from './ModalComponent';
+import { ModalContent } from './ModalContent';
+import { ModalFooter } from './ModalFooter';
+
+export { type ModalRef } from './ModalComponent';
+
+export const Modal = ModalComponent as ModalComponentProps & {
+  Footer: typeof ModalFooter;
+  Content: typeof ModalContent;
+};
+Modal.Footer = ModalFooter;
+Modal.Content = ModalContent;

--- a/src/Modal/modal-long-title.stories.tsx
+++ b/src/Modal/modal-long-title.stories.tsx
@@ -1,0 +1,38 @@
+import { useRef } from 'react';
+
+import { Button } from '../Button';
+import { Modal, type ModalRef } from './index';
+
+export default {
+  title: 'Components > Modal',
+};
+
+export const ModalStory = () => {
+  const modalRef = useRef<ModalRef>(null);
+  const openModal = () => {
+    modalRef.current?.openModal();
+  };
+
+  return (
+    <section className="space-y-6">
+      <h2>Modal with long title</h2>
+      <Button onPress={openModal}>Open modal</Button>
+
+      <Modal
+        ref={modalRef}
+        title="Example modal with a long title that is being truncated"
+        contentProps={{ className: 'max-w-xs' }}
+      >
+        <Modal.Content>
+          <p>
+            Example modal with a long title that is being truncated. <br />
+            By default, no max width is set on the modal. You have to set it through{' '}
+            <code>contentProps.className</code>.
+          </p>
+        </Modal.Content>
+      </Modal>
+    </section>
+  );
+};
+
+ModalStory.storyName = 'Long title';

--- a/src/Modal/modal.stories.tsx
+++ b/src/Modal/modal.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from '../Button';
 import { Modal, type ModalRef } from './index';
 
 export default {
-  title: 'Components',
+  title: 'Components > Modal',
 };
 
 export const ModalStory = () => {
@@ -32,24 +32,32 @@ export const ModalStory = () => {
       </p>
 
       <Modal ref={modalRef} title="Example modal" onClosed={() => setNb((nb) => nb + 1)}>
-        <p>With some text inside for content.</p>
-        You can close the modal by:
-        <ol className="leading-8">
-          <li>
-            Hitting <b>{'<Esc>'}</b> on your Keyboard,
-          </li>
-          <li>Clicking outside of the modal,</li>
-          <li>
-            Clicking the <X /> Icon at the top-right of the modal,
-          </li>
-          <li>Clicking the button below.</li>
-        </ol>
-        <Button className="h-9 rounded-md border px-2" onPress={closeModal}>
-          Close Modal
-        </Button>
+        <Modal.Content>
+          <p>
+            With some text inside for content.
+            <br />
+            This example uses both <code>Modal.Content</code> & <code>Modal.Footer</code> components.
+          </p>
+          You can close the modal by:
+          <ol className="leading-8">
+            <li>
+              Hitting <b>{'<Esc>'}</b> on your Keyboard,
+            </li>
+            <li>Clicking outside of the modal,</li>
+            <li>
+              Clicking the <X /> Icon at the top-right of the modal,
+            </li>
+            <li>Clicking the button below.</li>
+          </ol>
+        </Modal.Content>
+        <Modal.Footer>
+          <Button className="h-9 rounded-md border px-2" onPress={closeModal}>
+            Close Modal
+          </Button>
+        </Modal.Footer>
       </Modal>
     </section>
   );
 };
 
-ModalStory.storyName = 'Modal';
+ModalStory.storyName = 'Default';


### PR DESCRIPTION
closes #21 

- put title in `<h1>` (previously `<h3>`)
- put title & cross icon in a `header` tag
- inline cross icon (previously absolute)
- truncate title (no default max width)
- add new `Modal.Content` & `Modal.Footer` components that can be used at implementation time
- update Modal story
  - default story now uses new Content & Footer components
  - new story to show title being truncated
- small ladle config improvements