### PR TITLE
feat: add Modal.CloseButton

### DIFF
--- a/src/Button/button.stories.tsx
+++ b/src/Button/button.stories.tsx
@@ -26,6 +26,9 @@ export const ModalStory = () => {
         <p>
           <Button iconStart={Anchor} /> ← button with no text
         </p>
+        <p>
+          <Button variant="unstyled">Unstyled Button</Button>
+        </p>
       </div>
     </section>
   );

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -4,18 +4,20 @@ import cx from 'classnames';
 import { FC, PropsWithChildren, useRef } from 'react';
 import { Icon } from 'react-feather';
 
-interface ButtonProps extends AriaButtonProps<'button'> {
+export interface ButtonProps extends PropsWithChildren<AriaButtonProps<'button'>> {
   className?: string;
   iconStart?: Icon;
   iconEnd?: Icon;
   formMethod?: string | undefined;
+  variant?: 'regular' | 'unstyled';
 }
 
-export const Button: FC<PropsWithChildren<ButtonProps>> = ({
+export const Button: FC<ButtonProps> = ({
   children,
   className,
   iconStart: IconStart,
   iconEnd: IconEnd,
+  variant = 'regular',
   ...props
 }) => {
   const ref = useRef(null);
@@ -26,12 +28,13 @@ export const Button: FC<PropsWithChildren<ButtonProps>> = ({
       {...buttonProps}
       ref={ref}
       className={cx(
-        `inline-flex h-9 w-fit items-center space-x-2
-        rounded-md border border-gray-500 bg-gray-100
-        px-2 outline-none
-        dark:border-gray-400 dark:bg-gray-800 `,
+        variant !== 'unstyled' &&
+          `inline-flex h-9 w-fit items-center space-x-2
+          rounded-md border border-gray-500 bg-gray-100
+          px-2 outline-none
+          dark:border-gray-400 dark:bg-gray-800 `,
         buttonProps.disabled && 'cursor-not-allowed opacity-40',
-        !buttonProps.disabled && 'hover:bg-gray-200 hover:dark:bg-gray-700',
+        !buttonProps.disabled && variant !== 'unstyled' && 'hover:bg-gray-200 hover:dark:bg-gray-700',
         className
       )}
     >

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -8,6 +8,7 @@ interface ButtonProps extends AriaButtonProps<'button'> {
   className?: string;
   iconStart?: Icon;
   iconEnd?: Icon;
+  formMethod?: string | undefined;
 }
 
 export const Button: FC<PropsWithChildren<ButtonProps>> = ({

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -17,6 +17,7 @@ export const Button: FC<ButtonProps> = ({
   className,
   iconStart: IconStart,
   iconEnd: IconEnd,
+  formMethod,
   variant = 'regular',
   ...props
 }) => {
@@ -26,6 +27,7 @@ export const Button: FC<ButtonProps> = ({
   return (
     <button
       {...buttonProps}
+      formMethod={formMethod}
       ref={ref}
       className={cx(
         variant !== 'unstyled' &&

--- a/src/Modal/ModalCloseButton.tsx
+++ b/src/Modal/ModalCloseButton.tsx
@@ -1,11 +1,16 @@
 import { FC } from 'react';
 
 import { Button, ButtonProps } from '../Button';
+import { useModalContext } from './useModal';
 
-type ModalCloseButton = Omit<ButtonProps, 'type' | 'formMethod'>;
+type ModalCloseButton = Omit<ButtonProps, 'type' | 'formMethod' | 'onPress'>;
 
-export const ModalCloseButton: FC<ModalCloseButton> = ({ children, ...props }) => (
-  <Button type="submit" formMethod="dialog" {...props}>
-    {children}
-  </Button>
-);
+export const ModalCloseButton: FC<ModalCloseButton> = ({ children, ...props }) => {
+  const { closeModal } = useModalContext();
+
+  return (
+    <Button type="submit" formMethod="dialog" onPress={closeModal} {...props}>
+      {children}
+    </Button>
+  );
+};

--- a/src/Modal/ModalCloseButton.tsx
+++ b/src/Modal/ModalCloseButton.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+
+import { Button, ButtonProps } from '../Button';
+
+type ModalCloseButton = Omit<ButtonProps, 'type' | 'formMethod'>;
+
+export const ModalCloseButton: FC<ModalCloseButton> = ({ children, ...props }) => (
+  <Button type="submit" formMethod="dialog" {...props}>
+    {children}
+  </Button>
+);

--- a/src/Modal/ModalComponent.tsx
+++ b/src/Modal/ModalComponent.tsx
@@ -15,6 +15,7 @@ import {
 import { X } from 'react-feather';
 
 import { ModalCloseButton } from './ModalCloseButton';
+import { ModalContext } from './useModal';
 
 interface ModalFCProps {
   title: string;
@@ -102,51 +103,53 @@ export const ModalComponent: ModalComponentProps = forwardRef<ModalRef, PropsWit
     }, [closeModal, modalRef]);
 
     return (
-      <dialog
-        {...dialogProps}
-        ref={modalRef}
-        className={cx(
-          '!m-auto overflow-y-hidden bg-transparent backdrop:bg-gray-700/80 backdrop:backdrop-blur-sm',
-          dialogClassName
-        )}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <form
-          {...contentProps}
-          role="dialog"
-          aria-labelledby={titleId}
+      <ModalContext.Provider value={{ openModal, closeModal }}>
+        <dialog
+          {...dialogProps}
+          ref={modalRef}
           className={cx(
-            'relative flex flex-col rounded-xl p-6',
-            'bg-white text-base text-gray-500',
-            'dark:bg-gray-900 dark:fill-gray-400 dark:text-gray-400',
-            closing ? 'animate-modal-shrink opacity-0' : 'animate-modal-grow',
-            contentClassName
+            '!m-auto overflow-y-hidden bg-transparent backdrop:bg-gray-700/80 backdrop:backdrop-blur-sm',
+            dialogClassName
           )}
+          onClick={(e) => e.stopPropagation()}
         >
-          <header
-            {...headerProps}
-            className={cx('flex w-full items-center justify-between space-x-8', headerClassName)}
+          <form
+            {...contentProps}
+            role="dialog"
+            aria-labelledby={titleId}
+            className={cx(
+              'relative flex flex-col rounded-xl p-6',
+              'bg-white text-base text-gray-500',
+              'dark:bg-gray-900 dark:fill-gray-400 dark:text-gray-400',
+              closing ? 'animate-modal-shrink opacity-0' : 'animate-modal-grow',
+              contentClassName
+            )}
           >
-            <h1
-              {...titleProps}
-              id={titleId}
-              className={cx(
-                'm-0 grow truncate text-xl font-bold capitalize leading-8 text-black dark:text-white',
-                titleClassName
-              )}
+            <header
+              {...headerProps}
+              className={cx('flex w-full items-center justify-between space-x-8', headerClassName)}
             >
-              {title}
-            </h1>
-            <ModalCloseButton
-              variant="unstyled"
-              className="h-8 w-8 shrink-0 rounded-full p-1 outline-none hover:bg-gray-200 dark:hover:bg-gray-700"
-            >
-              <X />
-            </ModalCloseButton>
-          </header>
-          {children}
-        </form>
-      </dialog>
+              <h1
+                {...titleProps}
+                id={titleId}
+                className={cx(
+                  'm-0 grow truncate text-xl font-bold capitalize leading-8 text-black dark:text-white',
+                  titleClassName
+                )}
+              >
+                {title}
+              </h1>
+              <ModalCloseButton
+                variant="unstyled"
+                className="h-8 w-8 shrink-0 rounded-full p-1 outline-none hover:bg-gray-200 dark:hover:bg-gray-700"
+              >
+                <X />
+              </ModalCloseButton>
+            </header>
+            {children}
+          </form>
+        </dialog>
+      </ModalContext.Provider>
     );
   }
 );

--- a/src/Modal/ModalComponent.tsx
+++ b/src/Modal/ModalComponent.tsx
@@ -18,7 +18,7 @@ interface ModalFCProps {
   title: string;
   titleProps?: HTMLAttributes<HTMLHeadingElement>;
   headerProps?: HTMLAttributes<HTMLHeadElement>;
-  contentProps?: Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'aria-labelledby'>;
+  contentProps?: Omit<HTMLAttributes<HTMLFormElement>, 'role' | 'aria-labelledby'>;
   dialogProps?: HTMLAttributes<HTMLDialogElement>;
   onClosed?: () => void;
 }
@@ -109,7 +109,7 @@ export const ModalComponent: ModalComponentProps = forwardRef<ModalRef, PropsWit
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        <div
+        <form
           {...contentProps}
           role="dialog"
           aria-labelledby={titleId}
@@ -141,7 +141,7 @@ export const ModalComponent: ModalComponentProps = forwardRef<ModalRef, PropsWit
             />
           </header>
           {children}
-        </div>
+        </form>
       </dialog>
     );
   }

--- a/src/Modal/ModalComponent.tsx
+++ b/src/Modal/ModalComponent.tsx
@@ -14,6 +14,8 @@ import {
 } from 'react';
 import { X } from 'react-feather';
 
+import { ModalCloseButton } from './ModalCloseButton';
+
 interface ModalFCProps {
   title: string;
   titleProps?: HTMLAttributes<HTMLHeadingElement>;
@@ -135,10 +137,12 @@ export const ModalComponent: ModalComponentProps = forwardRef<ModalRef, PropsWit
             >
               {title}
             </h1>
-            <X
-              className="h-8 w-8 shrink-0 cursor-pointer rounded-full p-1 hover:bg-gray-200 dark:hover:bg-gray-700"
-              onClick={closeModal}
-            />
+            <ModalCloseButton
+              variant="unstyled"
+              className="h-8 w-8 shrink-0 rounded-full p-1 outline-none hover:bg-gray-200 dark:hover:bg-gray-700"
+            >
+              <X />
+            </ModalCloseButton>
           </header>
           {children}
         </form>

--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -1,3 +1,4 @@
+import { ModalCloseButton } from './ModalCloseButton';
 import { ModalComponent, ModalComponentProps } from './ModalComponent';
 import { ModalContent } from './ModalContent';
 import { ModalFooter } from './ModalFooter';
@@ -7,6 +8,8 @@ export { type ModalRef } from './ModalComponent';
 export const Modal = ModalComponent as ModalComponentProps & {
   Footer: typeof ModalFooter;
   Content: typeof ModalContent;
+  CloseButton: typeof ModalCloseButton;
 };
 Modal.Footer = ModalFooter;
 Modal.Content = ModalContent;
+Modal.CloseButton = ModalCloseButton;

--- a/src/Modal/modal.stories.tsx
+++ b/src/Modal/modal.stories.tsx
@@ -45,15 +45,22 @@ export const ModalStory = () => {
             </li>
             <li>Clicking outside of the modal,</li>
             <li>
-              Clicking the <X /> Icon at the top-right of the modal,
+              Clicking the <X /> Button at the top-right of the modal,
             </li>
-            <li>Clicking the button below.</li>
+            <li>Clicking either button below.</li>
           </ol>
         </Modal.Content>
-        <Modal.Footer>
-          <Button className="h-9 rounded-md border px-2" onPress={closeModal}>
-            Close Modal
-          </Button>
+        <Modal.Footer className="flex-col items-end space-y-2">
+          <div className="space-x-2">
+            <span className="italic">regular Button calling closeModal →</span>
+            <Button className="h-9 rounded-md border px-2" onPress={closeModal}>
+              Close Modal
+            </Button>
+          </div>
+          <div className="space-x-2">
+            <span className="italic">Modal.CloseButton →</span>
+            <Modal.CloseButton>Close Modal</Modal.CloseButton>
+          </div>
         </Modal.Footer>
       </Modal>
     </section>

--- a/src/Modal/useModal.tsx
+++ b/src/Modal/useModal.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+import { ModalRef } from './ModalComponent';
+
+export const ModalContext = createContext<ModalRef | null>(null);
+
+export const useModalContext = () => {
+  const context = useContext(ModalContext);
+
+  if (!context) throw Error('useModalContext used outside of ModalContext');
+
+  return context;
+};


### PR DESCRIPTION
- `Button` now supports `formMethod` property
- `Button` now supports `variant="unstyled"` property
- `Modal.CloseButton` added
- in `Modal`, use `Modal.CloseButton` instead of "just" an X icon
- update stories
  - Button: Unstyled Button
  - Modal: Modal.CloseButton + update wording